### PR TITLE
Select a random subset of topics for each iteration

### DIFF
--- a/src/inject/inject.js
+++ b/src/inject/inject.js
@@ -20,6 +20,7 @@ window.followrSendUserInfo = function(options) {
 
 $(function() {
 	var maxQueries = 12, // default queries
+		maxTopicsPerIteration = 4,
 		timeInbetweenTweets = 1500,
 		bindScoreToRealUserAction,
 		addToScore,
@@ -280,7 +281,7 @@ $(function() {
 						itemTemplate,
 						templates = [];
 
-					searchQueries = _.take(_.shuffle(searchQueries), 4);
+					searchQueries = _.take(_.shuffle(searchQueries), maxTopicsPerIteration);
 
 					// format queries
 					for (i = 0; i < searchQueries.length; i++) {


### PR DESCRIPTION
This allows the user to specify an unlimited number of favorite topics. On each iteration, the scope is limited to a random subset of `maxTopicsPerIteration` (default = 4) topics.
